### PR TITLE
Fix assert_file to assert_file_exist

### DIFF
--- a/after/syntax/bats.vim
+++ b/after/syntax/bats.vim
@@ -22,7 +22,7 @@ syntax keyword batsAssertions	assert_output containedin=shExpr contained
 syntax keyword batsAssertions	refute_output containedin=shExpr contained
 syntax keyword batsAssertions	assert_line containedin=shExpr contained
 syntax keyword batsAssertions	refute_line containedin=shExpr contained
-syntax keyword batsAssertions	assert_file containedin=shExpr contained
+syntax keyword batsAssertions	assert_file_exist containedin=shExpr contained
 syntax keyword batsAssertions	assert_file_not_exist containedin=shExpr contained
 
 " Link the colors to the existing group name. :h group-name


### PR DESCRIPTION
Fixing this typo. Turns out it was [`assert_file_exist`](https://github.com/ztombol/bats-file/blob/master/src/file.bash#L41) and not `assert_file`