### PR TITLE
Add g:bats_vim_consider_dollar_as_part_of_word

### DIFF
--- a/ftplugin/bats.vim
+++ b/ftplugin/bats.vim
@@ -5,7 +5,9 @@
 setlocal commentstring=#\ %s
 
 " Consider `$` as part of a word text object.
-setlocal iskeyword+=$
+if g:bats_vim_consider_dollar_as_part_of_word
+  setlocal iskeyword+=$
+endif
 
 " Go to files in `load` directives.
 setlocal suffixesadd=.bash

--- a/plugin/bats.vim
+++ b/plugin/bats.vim
@@ -1,0 +1,3 @@
+if !exists('g:bats_vim_consider_dollar_as_part_of_word')
+  let g:bats_vim_consider_dollar_as_part_of_word = 1
+endif

--- a/readme.md
+++ b/readme.md
@@ -34,5 +34,13 @@ Using [Vundle](https://github.com/gmarik/vundle):
 Plugin 'aliou/bats.vim'
 ```
 
+## Configuration
+
+### `g:bats_vim_consider_dollar_as_part_of_word`
+
+Default: `1`
+
+Whether or not to add dollar sign to iskeyword.
+
 ## License
 Copyright © Aliou Diallo. Distributed under the same terms as Vim itself. See `:help license.`


### PR DESCRIPTION
When you search for the word `$var` in the following code, you will jump to `$var`.
You can't jump to `${var}`
This is because we are adding a dollar sign to the iskeyword.

```
echo "$var"
echo "${var}"
````

When you merge this pull request, bats.vim user can decide whether or not to add the dollar sign to the iskeyword by using option.